### PR TITLE
fix: prevent video full screen in webview (#39)

### DIFF
--- a/src/components/pages/chat/ChatVideo.tsx
+++ b/src/components/pages/chat/ChatVideo.tsx
@@ -80,7 +80,13 @@ export default function ChatVideo({
         setShowController(!showController);
       }}
     >
-      <StyledVideo id="video" ref={ref} onTimeUpdate={onSink}>
+      <StyledVideo
+        id="video"
+        ref={ref}
+        playsInline
+        poster={thumbnailUrl}
+        onTimeUpdate={onSink}
+      >
         <source src={videoUrl} />
         <track kind="captions" />
       </StyledVideo>


### PR DESCRIPTION
## PR Type

<!-- 해당되는 것들을 제외하곤 지워주세요. -->

- 🐛 Bugfix


## 작업 내용 (Content)

<!-- 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다. -->

- webview 환경에서 video 전체모드가 되는 것을 막았습니다.
- 이미지가 로딩될때나 처음 로드되어 재생버튼을 누르기 전까지 보여줄 썸네일 이미지 속성을 추가하였습니다.

## 링크 (Links)

- resolved #39 