### PR TITLE
fix: move to login page when refresh logic failed (#54)

### DIFF
--- a/src/util/AuthRoute.tsx
+++ b/src/util/AuthRoute.tsx
@@ -15,22 +15,28 @@ function AuthRoute() {
     const token = Cookies.get('refresh');
 
     if (token) {
-      const { data } = await AUTH_API.refresh(token);
-      setIsLoggedIn(true);
+      try {
+        const { data } = await AUTH_API.refresh(token);
+        setIsLoggedIn(true);
 
-      Cookies.set('refresh', data.refreshToken);
-      fetcher.setAccessToken(data.accessToken);
+        Cookies.set('refresh', data.refreshToken);
+        fetcher.setAccessToken(data.accessToken);
 
-      await userStore.getUserData(data.userId);
-      userStore.setRefreshTimer();
+        await userStore.getUserData(data.userId);
+        userStore.setRefreshTimer();
 
-      await USER_API.getUserIsCouple(data.userId).then((res) => {
-        if (res.data.result) {
-          navigate('/', { replace: true });
-        } else {
-          navigate('/login/select', { replace: true });
-        }
-      });
+        await USER_API.getUserIsCouple(data.userId).then((res) => {
+          if (res.data.result) {
+            navigate('/', { replace: true });
+          } else {
+            navigate('/login/select', { replace: true });
+          }
+        });
+      } catch {
+        Cookies.remove('refresh');
+        setIsLoggedIn(false);
+        navigate('/login/kakao', { replace: true });
+      }
     } else {
       setIsLoggedIn(false);
       navigate('/login/kakao', { replace: true });


### PR DESCRIPTION
## PR Type

<!-- 해당되는 것들을 제외하곤 지워주세요. -->

- 🐛 Bugfix

## 작업 내용 (Content)

<!-- 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다. -->

- refresh token이 잘못되었을 때, 이를 제거해주지 않으면 계속 오류가 발생합니다. 따라서 로그인 과정에서 오류가 발생했을시, token을 다 제거하고 로그인 페이지로 돌아가게 만들었습니다.

## 링크 (Links)

- resolved #54 

